### PR TITLE
Add ASP.NET extension package

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -2,10 +2,9 @@
 name: Publish NuGet package
 
 on:
-  workflow_dispatch:
   push:
-    branches:
-      - main
+    tags: 
+      - 'v*.*.*'
 
 env:
   ARTIFACTS_FEED_URL: https://api.nuget.org/v3/index.json
@@ -13,31 +12,13 @@ env:
   DOTNET_VERSION: "6.x"
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       # Checkout the repo
       - uses: actions/checkout@v2
-
-      # Setup .NET Core SDK
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-
-      # Run dotnet build and package
-      - name: dotnet build and test
-        run: |
-          dotnet restore
-          dotnet build --configuration '${{ env.BUILD_CONFIGURATION }}'
-          dotnet test --configuration '${{ env.BUILD_CONFIGURATION }}'
-
-  az-artifacts-build-and-deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      # Checkout the repo
-      - uses: actions/checkout@v2
+          fetch-depth: 0 # Needed for GitVersion to function correctly
 
       # Setup .NET Core SDK
       - name: Setup .NET Core
@@ -48,12 +29,20 @@ jobs:
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY_NEOLUTION }}
 
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.7
+        with:
+          versionSpec: '5.x'
+          
+      - name: Determine version number
+        uses: gittools/actions/gitversion/execute@v0.9.7
+
       # Run dotnet build and package
       - name: dotnet build and publish
         run: |
           dotnet restore
           dotnet build --configuration '${{ env.BUILD_CONFIGURATION }}'
-          dotnet pack -c '${{ env.BUILD_CONFIGURATION }}'
+          dotnet pack --configuration '${{ env.BUILD_CONFIGURATION }}' --no-build -p:PackageVersion=$GITVERSION_NUGETVERSION
 
       # Publish the package to Azure Artifacts
       - name: "dotnet publish"

--- a/GoogleSecrets.sln
+++ b/GoogleSecrets.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31515.178
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32804.467
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GoogleSecrets", "GoogleSecrets\GoogleSecrets.csproj", "{C7B9C660-1ABC-4DAE-B7C3-DB18810D3794}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GoogleSecrets", "GoogleSecrets\GoogleSecrets.csproj", "{C7B9C660-1ABC-4DAE-B7C3-DB18810D3794}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Neolution.AspNetCore.GoogleSecrets", "Neolution.AspNetCore.GoogleSecrets\Neolution.AspNetCore.GoogleSecrets.csproj", "{05C95A35-1E43-4526-A6C9-49D7048F2083}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{C7B9C660-1ABC-4DAE-B7C3-DB18810D3794}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C7B9C660-1ABC-4DAE-B7C3-DB18810D3794}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C7B9C660-1ABC-4DAE-B7C3-DB18810D3794}.Release|Any CPU.Build.0 = Release|Any CPU
+		{05C95A35-1E43-4526-A6C9-49D7048F2083}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{05C95A35-1E43-4526-A6C9-49D7048F2083}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{05C95A35-1E43-4526-A6C9-49D7048F2083}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{05C95A35-1E43-4526-A6C9-49D7048F2083}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GoogleSecrets.sln
+++ b/GoogleSecrets.sln
@@ -7,6 +7,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GoogleSecrets", "GoogleSecr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Neolution.AspNetCore.GoogleSecrets", "Neolution.AspNetCore.GoogleSecrets\Neolution.AspNetCore.GoogleSecrets.csproj", "{05C95A35-1E43-4526-A6C9-49D7048F2083}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FF9F458C-59A4-42B7-811D-95A1CEFC862C}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\dotnet-publish.yml = .github\workflows\dotnet-publish.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/GoogleSecrets/GoogleSecrets.csproj
+++ b/GoogleSecrets/GoogleSecrets.csproj
@@ -1,29 +1,30 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <RootNamespace>Neolution.Extensions.Configuration.GoogleSecrets</RootNamespace>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageId>Neolution.Extensions.Configuration.GoogleSecrets</PackageId>
-    <Authors>Neolution AG</Authors>
-    <Company>Neolution AG</Company>
-    <Product>Add Google Secrets to the Configuration</Product>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageVersion>1.1.7</PackageVersion>
- </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.1</TargetFramework>
+		<RootNamespace>Neolution.Extensions.Configuration.GoogleSecrets</RootNamespace>
+		<PackageId>Neolution.Extensions.Configuration.GoogleSecrets</PackageId>
+		<Authors>Neolution AG</Authors>
+		<Company>Neolution AG</Company>
+		<Product>Neolution GoogleSecrets Configuration</Product>
+		<PackageProjectUrl>https://github.com/neolution-ch/Neolution.Extensions.Configuration.GoogleSecrets</PackageProjectUrl>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<Description>Add Google Secrets to the Configuration</Description>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="ReadMe.txt">
-      <Pack>true</Pack>
-      <PackagePath>\</PackagePath>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Include="ReadMe.txt">
+			<Pack>true</Pack>
+			<PackagePath>\</PackagePath>
+		</Content>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Google.Cloud.SecretManager.V1" Version="1.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Google.Cloud.SecretManager.V1" Version="1.8.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.0" />
+	</ItemGroup>
 
 </Project>

--- a/Neolution.AspNetCore.GoogleSecrets/Neolution.AspNetCore.GoogleSecrets.csproj
+++ b/Neolution.AspNetCore.GoogleSecrets/Neolution.AspNetCore.GoogleSecrets.csproj
@@ -1,21 +1,35 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<Authors>Neolution AG</Authors>
+		<Company>Neolution AG</Company>
+		<Product>Neolution GoogleSecrets for ASP.NET</Product>
+		<Description>Adds Google Secrets to the Configuration for ASP.NET applications</Description>
+		<PackageProjectUrl>https://github.com/neolution-ch/Neolution.Extensions.Configuration.GoogleSecrets</PackageProjectUrl>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Neolution.CodeAnalysis" Version="2.5.9">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Neolution.CodeAnalysis" Version="2.5.9">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\GoogleSecrets\GoogleSecrets.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\GoogleSecrets\GoogleSecrets.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Update="README.md">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/Neolution.AspNetCore.GoogleSecrets/Neolution.AspNetCore.GoogleSecrets.csproj
+++ b/Neolution.AspNetCore.GoogleSecrets/Neolution.AspNetCore.GoogleSecrets.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Neolution.CodeAnalysis" Version="2.5.9">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GoogleSecrets\GoogleSecrets.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Neolution.AspNetCore.GoogleSecrets/README.md
+++ b/Neolution.AspNetCore.GoogleSecrets/README.md
@@ -1,0 +1,35 @@
+﻿# Neolution GoogleSecrets for ASP.NET
+
+Inside `Program.cs` add `ConfigureGoogleSecrets()` to the WebHost builder.
+
+    private static IWebHostBuilder CreateWebHostBuilder(string[] args)
+    {
+        return WebHost.CreateDefaultBuilder(args)
+            .ConfigureGoogleSecrets() // <--
+            .UseStartup<Startup>();
+    }
+
+When you want to load the secrets on application start, add the ProjectID assigned to your Google Secrets Manager with the following environment variable to the system:
+
+    GOOGLE_SECRETS_PROJECT_ID
+
+## On development machines
+
+Add the environment variable to the launchSettings.json file. E.g.
+
+    {
+      "profiles": {
+        "IIS Express": {
+          "commandName": "IISExpress",
+          "launchBrowser": true,
+          "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development",
+            "GOOGLE_SECRETS_PROJECT_ID": "your-gcloud-project-id" // <--
+          }
+        }
+      }
+    }
+
+## On Google Cloud Run
+
+Create a new revision of your web application and add a environment variable named `GOOGLE_SECRETS_PROJECT_ID` with your ProjectID as the value.

--- a/Neolution.AspNetCore.GoogleSecrets/WebHostBuilderExtensions.cs
+++ b/Neolution.AspNetCore.GoogleSecrets/WebHostBuilderExtensions.cs
@@ -1,0 +1,48 @@
+﻿namespace Neolution.AspNetCore.GoogleSecrets
+{
+    using Microsoft.AspNetCore.Hosting;
+    using Neolution.Extensions.Configuration.GoogleSecrets;
+
+    /// <summary>
+    /// Google Secrets extensions for <see cref="IWebHostBuilder"/>.
+    /// </summary>
+    public static class WebHostBuilderExtensions
+    {
+        /// <summary>
+        /// Gets the Google Secrets project identifier.
+        /// </summary>
+        private static string GoogleSecretsProjectId => Environment.GetEnvironmentVariable("GOOGLE_SECRETS_PROJECT_ID") ?? string.Empty;
+
+        /// <summary>
+        /// Gets a value indicating whether to load Google Secrets.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> to load Google Secrets; otherwise, <c>false</c>.
+        /// </value>
+        private static bool LoadGoogleSecrets => !string.IsNullOrWhiteSpace(GoogleSecretsProjectId);
+
+        /// <summary>
+        /// Configures the Google Secrets in the web host.
+        /// </summary>
+        /// <param name="webHostBuilder">The web host builder.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        public static IWebHostBuilder ConfigureGoogleSecrets(this IWebHostBuilder webHostBuilder)
+        {
+            if (webHostBuilder is null)
+            {
+                throw new ArgumentNullException(nameof(webHostBuilder));
+            }
+
+            return webHostBuilder.ConfigureAppConfiguration((_, configBuilder) =>
+            {
+                if (LoadGoogleSecrets)
+                {
+                    configBuilder.AddGoogleSecrets(options =>
+                    {
+                        options.ProjectName = GoogleSecretsProjectId;
+                    });
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
This allows the use of a `GOOGLE_SECRETS_PROJECT_ID` environment variable to control if and which secrets will be configured for the application on startup.