### PR TITLE
Fix issues with GoogleSecret syntax and version parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and adheres to a project-specific [Versioning](/README.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue where the `GoogleSecret:SecretName:SecretVersion` syntax was not working as expected. Instead of using a starts with comparison, the code now uses a regular expression to match the secret name and version.
+- Fixed an issue where the `GoogleSecret:SecretName:SecretVersion` syntax was not working as expected. The version was parsed including the `}` character. The code now removes the `}` character from the version before calling the google api.
+
 ## [1.3.0] - 2024-03-12
 
 ### Added


### PR DESCRIPTION
This pull request fixes two issues with the `GoogleSecret:SecretName:SecretVersion` syntax and version parsing in the `GoogleSecretsProvider.cs` file. The code now uses a regular expression to match the secret name and version, and removes the `}` character from the version before calling the Google API.