### PR TITLE
Add log message for Google Secrets project loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to a project-specific [Versioning](/README.md).
 
 ## [Unreleased]
 
+### Added
+
+- Added a log message to indicate which project is being used for Google Secrets. This is useful for debugging and understanding which project is being used when multiple projects are available.
+
 ## [1.5.0] - 2025-04-15
 
 ### Added

--- a/GoogleSecrets/GoogleSecretsProvider.cs
+++ b/GoogleSecrets/GoogleSecretsProvider.cs
@@ -51,6 +51,8 @@
                     return;
                 }
 
+                this.logger.LogInformation($"Loading secrets from project {this.Source.ProjectName}");
+
                 // Create client
                 SecretManagerServiceClient secretManagerServiceClient = SecretManagerServiceClient.Create();
 


### PR DESCRIPTION
Introduce a log message to indicate which Google Secrets project is being loaded, enhancing debugging capabilities when multiple projects are in use.